### PR TITLE
Add pressure sensor simulation support and tests (#29)

### DIFF
--- a/Assignment-12/models.py
+++ b/Assignment-12/models.py
@@ -22,8 +22,9 @@ class Configuration(BaseModel):
     temperature_range: dict = {"min": 18.0, "max": 25.0}
     humidity_range: dict = {"min": 30.0, "max": 70.0}
     water_flow_range: dict = {"min": 0.0, "max": 100.0}
+    pressure_range: dict = {"min": 950.0, "max": 1050.0}
     deterministic_mode: bool = False
-    enabled_sensors: List[str] = ["temperature", "humidity", "water"]
+    enabled_sensors: List[str] = ["temperature", "humidity", "water", "pressure"]
 
 
 class SimulationLog(BaseModel):

--- a/Assignment-12/services/sensor_reading_service.py
+++ b/Assignment-12/services/sensor_reading_service.py
@@ -19,6 +19,8 @@ class SensorReadingService:
             raise ValueError("Humidity must be between 30 and 70")
         if reading.sensor_type == "water" and not (0 <= reading.value <= 100):
             raise ValueError("Water flow must be between 0 and 100")
+        if reading.sensor_type == "pressure" and not (950 <= reading.value <= 1050):
+            raise ValueError("Pressure must be between 950 and 1050 hPa")
         self.repo.save(reading)
         return reading
     

--- a/Assignment-12/tests/test_api.py
+++ b/Assignment-12/tests/test_api.py
@@ -52,10 +52,39 @@ def test_delete_reading():
     assert get_resp.status_code == 404
 
 
+def test_create_pressure_reading():
+    response = client.post("/api/readings", json={
+        "reading_id": "p1",
+        "sensor_id": "s5",
+        "sensor_type": "pressure",
+        "value": 1013.25
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["reading_id"] == "p1"
+    assert data["sensor_type"] == "pressure"
+    assert data["value"] == 1013.25
+
+
+def test_create_invalid_pressure_reading():
+    response = client.post("/api/readings", json={
+        "reading_id": "p2",
+        "sensor_id": "s5",
+        "sensor_type": "pressure",
+        "value": 500.0
+    })
+    assert response.status_code == 400
+    assert "Pressure must be between 950 and 1050 hPa" in response.text
+
+
 def test_get_config():
     response = client.get("/api/config")
     assert response.status_code == 200
-    assert response.json()["update_frequency"] == 5
+    data = response.json()
+    assert data["update_frequency"] == 5
+    assert "pressure_range" in data
+    assert data["pressure_range"] == {"min": 950.0, "max": 1050.0}
+    assert "pressure" in data["enabled_sensors"]
 
 
 def test_update_config():

--- a/Assignment-12/tests/test_services.py
+++ b/Assignment-12/tests/test_services.py
@@ -43,6 +43,32 @@ class TestSensorReadingService:
         self.service.delete_reading("r1")
         assert self.service.get_reading("r1") is None
 
+    def test_create_valid_pressure_reading(self):
+        reading = SensorReading(reading_id="p1", sensor_id="s5", sensor_type="pressure", value=1013.25)
+        result = self.service.create_reading(reading)
+        assert result.reading_id == "p1"
+        assert result.sensor_type == "pressure"
+
+    def test_create_pressure_reading_at_min_boundary(self):
+        reading = SensorReading(reading_id="p2", sensor_id="s5", sensor_type="pressure", value=950.0)
+        result = self.service.create_reading(reading)
+        assert result.value == 950.0
+
+    def test_create_pressure_reading_at_max_boundary(self):
+        reading = SensorReading(reading_id="p3", sensor_id="s5", sensor_type="pressure", value=1050.0)
+        result = self.service.create_reading(reading)
+        assert result.value == 1050.0
+
+    def test_create_invalid_pressure_too_low(self):
+        reading = SensorReading(reading_id="p4", sensor_id="s5", sensor_type="pressure", value=800.0)
+        with pytest.raises(ValueError, match="Pressure must be between 950 and 1050 hPa"):
+            self.service.create_reading(reading)
+
+    def test_create_invalid_pressure_too_high(self):
+        reading = SensorReading(reading_id="p5", sensor_id="s5", sensor_type="pressure", value=1200.0)
+        with pytest.raises(ValueError, match="Pressure must be between 950 and 1050 hPa"):
+            self.service.create_reading(reading)
+
 
 class TestConfigurationService:
     def setup_method(self):


### PR DESCRIPTION
- Implement pressure sensor support in [Assignment-12](vscode-file://vscode-app/c:/Users/mabot/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Add pressure_range to [Configuration](vscode-file://vscode-app/c:/Users/mabot/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Include pressure in enabled_sensors
- Add pressure validation in [SensorReadingService](vscode-file://vscode-app/c:/Users/mabot/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Add API tests for valid and invalid pressure readings
- Add service tests for pressure boundary values and invalid ranges